### PR TITLE
[FEAT] 공지사항 검색 쿼리를 Full Text Search 쿼리로 수정 및 페이지 네이션 정렬 기준 추가

### DIFF
--- a/dmforu-infrastructure/storage/mysql/src/main/kotlin/com/dmforu/storage/db/mysql/notice/NoticeEntityRepository.kt
+++ b/dmforu-infrastructure/storage/mysql/src/main/kotlin/com/dmforu/storage/db/mysql/notice/NoticeEntityRepository.kt
@@ -23,7 +23,7 @@ internal class NoticeEntityRepository(
         page: Int,
         size: Int,
     ): List<Notice> {
-        val pageable = pageRequest(page, size)
+        val pageable = createPageRequestByDateAndIdDesc(page, size)
         val noticePage = noticeJpaRepository.findBySearchWordAndDepartment(searchWord, department, pageable)
         return noticePage.map { it.toNotice() }.toList()
     }
@@ -33,13 +33,13 @@ internal class NoticeEntityRepository(
         page: Int,
         size: Int,
     ): List<Notice> {
-        val pageable = pageRequest(page, size)
+        val pageable = createPageRequestByNumberDesc(page, size)
         val departmentNoticePage = noticeJpaRepository.findByType(department, pageable)
         return departmentNoticePage.map { it.toNotice() }.toList()
     }
 
     override fun findUniversityNotices(page: Int, size: Int): List<Notice> {
-        val pageable = pageRequest(page, size)
+        val pageable = createPageRequestByNumberDesc(page, size)
         val universityNoticePage = noticeJpaRepository.findByType("대학", pageable)
         return universityNoticePage.map { it.toNotice() }.toList()
     }
@@ -48,7 +48,15 @@ internal class NoticeEntityRepository(
         return noticeJpaRepository.findMaxNumberByType(type)
     }
 
-    private fun pageRequest(page: Int, size: Int): PageRequest {
+    private fun createPageRequestByNumberDesc(page: Int, size: Int): PageRequest {
+        return PageRequest.of(
+            page - 1, size, Sort.by(
+                Sort.Order.desc("number")
+            )
+        )
+    }
+
+    private fun createPageRequestByDateAndIdDesc(page: Int, size: Int): PageRequest {
         return PageRequest.of(
             page - 1, size, Sort.by(
                 Sort.Order.desc("date"),

--- a/dmforu-infrastructure/storage/mysql/src/main/kotlin/com/dmforu/storage/db/mysql/notice/NoticeJpaRepository.kt
+++ b/dmforu-infrastructure/storage/mysql/src/main/kotlin/com/dmforu/storage/db/mysql/notice/NoticeJpaRepository.kt
@@ -7,7 +7,8 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 internal interface NoticeJpaRepository : JpaRepository<NoticeEntity, Long> {
-    /** 원하는 타입의 가장 최신 공지사항 번호를 확인하는 메서드
+    /**
+     * 원하는 타입의 가장 최신 공지사항 번호를 확인하는 메서드
      *
      * @Param type (학과 이름 또는 대학)
      * @Return type에 알맞는 최신 공지사항 번호, 만약 공지사항이 존재하지 않다면 Null을 반환한다.
@@ -33,7 +34,12 @@ internal interface NoticeJpaRepository : JpaRepository<NoticeEntity, Long> {
      * @return 키워드에 맞는 공지사항 페이지
      */
     @Query(
-        value = "SELECT * FROM notice WHERE REPLACE(title, ' ', '') LIKE CONCAT('%', REPLACE(?1, ' ', ''), '%') AND type IN (?2, '대학')",
+        value = """
+            SELECT * 
+            FROM notice 
+            WHERE MATCH(title) AGAINST (?1 IN NATURAL LANGUAGE MODE)
+            ORDER BY date DESC, id DESC
+        """,
         nativeQuery = true
     )
     fun findBySearchWordAndDepartment(searchWord: String, department: String, pageable: Pageable): Page<NoticeEntity>


### PR DESCRIPTION
### Description
- LIKE 연산으로 처리하던 전체 검색 쿼리를 Full Text Search 쿼리로 수정
- 인덱싱을 위해 date, id로 정렬되던 페이지네이션의 기준을 number로 수정